### PR TITLE
Update query to match new schema, create view dataset when does not exist 

### DIFF
--- a/functions/bigquery_tools.py
+++ b/functions/bigquery_tools.py
@@ -11,7 +11,7 @@ query_path = os.path.join(
 
 def dataset_exists(
     bq_client, 
-    dataset_id
+    dataset_id 
     ):
     """
     Check dataset existence for the following id structure: {project_id}.{dataset_id}.
@@ -54,11 +54,13 @@ def create_dataset(
     ):
         raise NotFound(f"Dataset {CARBON_PROJECT}.{CARBON_DATASET} is not found, please make sure it exists.")
     
-    view_dataset_info = bq_client.get_dataset(
-        f"{VIEW_PROJECT}.{VIEW_DATASET}"
-    )
+    # Retrieving Billing and Carbon dataset
     billing_dataset_info = bq_client.get_dataset(
         f"{BILLING_PROJECT}.{BILLING_DATASET}"
+    )
+
+    carbon_dataset_info = bq_client.get_dataset(
+            f"{CARBON_PROJECT}.{CARBON_DATASET}"
     )
 
     if dataset_exists(
@@ -66,8 +68,8 @@ def create_dataset(
         f"{VIEW_PROJECT}.{VIEW_DATASET}"
     ):
         # If the final dataset already exists, check that all datasets are in the same location
-        carbon_dataset_info = bq_client.get_dataset(
-            f"{CARBON_PROJECT}.{CARBON_DATASET}"
+        view_dataset_info = bq_client.get_dataset(
+            f"{VIEW_PROJECT}.{VIEW_DATASET}"
         )
         
         if not (view_dataset_info.location == billing_dataset_info.location == carbon_dataset_info.location):
@@ -76,6 +78,7 @@ def create_dataset(
         if not (billing_dataset_info.location == carbon_dataset_info.location):
             raise ValueError("Billing and carbon datasets need to be in the same location to create the final view.")
         
+        # Create the View dataset object if it does not already exist
         dataset = bigquery.Dataset(
             f"{VIEW_PROJECT}.{VIEW_DATASET}"
         )

--- a/resources/view_template.sql
+++ b/resources/view_template.sql
@@ -1,41 +1,51 @@
-CREATE OR REPLACE VIEW
-  $VIEW_PROJECT_ID.$VIEW_DATASET.$VIEW_NAME AS
-SELECT
-  billing.billing_account_id,
-  STRUCT(billing.service_id AS id,
-    billing.service_description AS description) AS service,
-  STRUCT(billing.project_id AS id,
-    billing.project_number AS number,
-    billing.project_name AS name) AS project,
-  STRUCT(billing.location_location AS location,
-    billing.location_country AS country,
-    billing.location_region AS region,
-    billing.location_zone AS zone) AS location,
-  billing.billing_invoice_month AS usage_month,
-  billing.monthly_cost,
-  billing.monthly_net_cost, 
-  carbon.carbon_footprint_kgCO2e,
-  label_asset.labels,
-  billing_usage.monthly_usage_volume
-FROM (
+CREATE OR REPLACE VIEW 
+  `$VIEW_PROJECT_ID.$VIEW_DATASET.$VIEW_NAME` AS
+
+WITH carbon AS (
+  SELECT
+        billing_account_id,
+        usage_month,
+        service.id AS service_id,
+        project.number AS project_number,
+        location.location AS location_location,
+        ROUND(carbon_footprint_total_kgCO2e.location_based, 3) AS carbon_footprint_kgCO2e, -- Kept the previous name of the field for retrocompatibility with the dashboard downstream
+        ROUND(carbon_footprint_total_kgCO2e.market_based, 3) AS carbon_footprint_kgCO2e_market_based,
+        ROUND(carbon_footprint_kgCO2e.scope1, 3) AS scope1,
+        STRUCT(
+          ROUND(carbon_footprint_kgCO2e.scope2.location_based) AS location_based, 
+          ROUND(carbon_footprint_kgCO2e.scope2.market_based) AS market_based
+          ) AS scope2,
+        ROUND(carbon_footprint_kgCO2e.scope3, 3) AS scope3
+    FROM 
+      `$CARBON_PROJECT_ID.$CARBON_DATASET.$CARBON_TABLE`
+),
+
+billing AS (
   SELECT
     billing_account_id,
     service.id AS service_id,
     service.description AS service_description,
-    project.id AS project_id,
-    project.number AS project_number,
-    project.name AS project_name,
+    project_id,
+    project_number,
+    project_name,
     location.location AS location_location,
     location.country AS location_country,
     location.region AS location_region,
     location.zone AS location_zone,
-    DATE(PARSE_DATE("%Y%m",
-        invoice.month)) AS billing_invoice_month,
+    billing_invoice_month,
     ROUND(SUM(cost), 3) AS monthly_cost,
     ROUND(SUM(net_cost), 3) AS monthly_net_cost,
   FROM (
     SELECT
-      *,
+      billing_account_id,
+      service,
+      project.id AS project_id,
+      project.number AS project_number,
+      project.name AS project_name,
+      location,
+      DATE(PARSE_DATE("%Y%m",
+        invoice.month)) AS billing_invoice_month,
+      cost,
       COALESCE((
         SELECT
           SUM(x.amount)
@@ -43,38 +53,25 @@ FROM (
           UNNEST(billing.credits) x),
         0) + cost AS net_cost
     FROM
-      `$BILLING_PROJECT_ID.$BILLING_DATASET.$BILLING_TABLE` billing
+      `$BILLING_PROJECT_ID.$BILLING_DATASET.$BILLING_TABLE` AS billing
     WHERE
-      currency = "$CURRENCY")
+      currency = "USD"
+    )
   GROUP BY
     billing_account_id,
-    service.id,
-    service.description,
-    project.id,
-    project.number,
-    project.name,
+    service_id,
+    service_description,
+    project_id,
+    project_number,
+    project_name,
     location_location,
-    location.country,
+    location_country,
     location_region,
     location_zone,
-    billing_invoice_month) billing
-INNER JOIN (
-  SELECT
-    billing_account_id,
-    usage_month,
-    service.id AS service_id,
-    project.number AS project_number,
-    location.location AS location_location,
-    ROUND(carbon_footprint_kgCO2e, 3) AS carbon_footprint_kgCO2e,
-  FROM
-    `$CARBON_PROJECT_ID.$CARBON_DATASET.$CARBON_TABLE` ) carbon
-ON
-  carbon.project_number = billing.project_number
-  AND carbon.billing_account_id = billing.billing_account_id
-  AND carbon.usage_month = billing.billing_invoice_month
-  AND carbon.location_location = billing.location_location
-  AND carbon.service_id = billing.service_id
-LEFT JOIN (
+    billing_invoice_month
+  ),
+
+label_asset AS (
   SELECT
     number,
     ARRAY_AGG(STRUCT(key AS key,
@@ -86,12 +83,13 @@ LEFT JOIN (
       labels.value
     FROM
       `$BILLING_PROJECT_ID.$BILLING_DATASET.$BILLING_TABLE`,
-      UNNEST(project.labels) labels)
+      UNNEST(project.labels) labels
+    )
   GROUP BY
-    1) label_asset
-ON
-  billing.project_number = label_asset.number
-LEFT JOIN (
+    1
+),
+
+billing_usage AS (
   SELECT
     billing_account_id,
     service_id,
@@ -113,7 +111,7 @@ LEFT JOIN (
     FROM
       `$BILLING_PROJECT_ID.$BILLING_DATASET.$BILLING_TABLE`
     WHERE
-      currency = "$CURRENCY"
+      currency = "USD" 
     GROUP BY
       billing_account_id,
       service.id,
@@ -126,10 +124,51 @@ LEFT JOIN (
     service_id,
     project_number,
     location_location,
-    billing_invoice_month ) billing_usage
-ON
-  billing_usage.project_number = billing.project_number
-  AND billing_usage.billing_account_id = billing.billing_account_id
-  AND billing_usage.billing_invoice_month = billing.billing_invoice_month
-  AND billing_usage.location_location = billing.location_location
-  AND billing_usage.service_id = billing.service_id
+    billing_invoice_month 
+)
+
+SELECT 
+  b.billing_account_id,
+  STRUCT(
+    b.service_id AS id,
+    b.service_description AS description) AS service,
+  STRUCT(
+    b.project_id AS id,
+    b.project_number AS number,
+    b.project_name AS name
+  ) AS project,
+  STRUCT(
+    b.location_location AS location,
+    b.location_country AS country,
+    b.location_region AS region,
+    b.location_zone AS zone
+  ) AS location,
+  b.billing_invoice_month AS usage_month,
+  b.monthly_cost,
+  b.monthly_net_cost, 
+  c.carbon_footprint_kgCO2e,
+  c.carbon_footprint_kgCO2e_market_based,
+  c.scope1,
+  c.scope2,
+  c.scope3,
+  l.labels,
+  billing_usage.monthly_usage_volume
+FROM billing AS b
+INNER JOIN carbon AS c
+  ON
+    c.project_number = b.project_number
+    AND c.billing_account_id = b.billing_account_id
+    AND c.usage_month = b.billing_invoice_month
+    AND c.location_location = b.location_location
+    AND c.service_id = b.service_id
+LEFT JOIN label_asset AS l
+  ON
+    b.project_number = l.number
+LEFT JOIN billing_usage 
+  ON
+    billing_usage.project_number = b.project_number
+    AND billing_usage.billing_account_id = b.billing_account_id
+    AND billing_usage.billing_invoice_month = b.billing_invoice_month
+    AND billing_usage.location_location = b.location_location
+    AND billing_usage.service_id = b.service_id
+    

--- a/resources/view_template.sql
+++ b/resources/view_template.sql
@@ -55,7 +55,7 @@ billing AS (
     FROM
       `$BILLING_PROJECT_ID.$BILLING_DATASET.$BILLING_TABLE` AS billing
     WHERE
-      currency = "USD"
+      currency = "$CURRENCY"
     )
   GROUP BY
     billing_account_id,
@@ -111,7 +111,7 @@ billing_usage AS (
     FROM
       `$BILLING_PROJECT_ID.$BILLING_DATASET.$BILLING_TABLE`
     WHERE
-      currency = "USD" 
+      currency = "$CURRENCY" 
     GROUP BY
       billing_account_id,
       service.id,


### PR DESCRIPTION
1. The `carbon_footprint` table schema changed:

- `carbon_footprint_kgCO2e` that was previously a `FLOAT` is now a `STRUCT`

- The field `carbon_footprint_total_kgCO2e.location_based` is used instead, while keeping the same alias as before for backward compatibility reasons with the dashboard downstream.

2. Updated `bigquery_tools.py` as the script tried retrieving the `VIEW_DATASET` before checking it actually existed, which led to an exception being raised in cases where the `VIEW_DATASET` did not exist.