### PR TITLE
fix: mismatch with new carbon footprint schema

### DIFF
--- a/resources/view_template.sql
+++ b/resources/view_template.sql
@@ -14,7 +14,10 @@ SELECT
   billing.billing_invoice_month AS usage_month,
   billing.monthly_cost,
   billing.monthly_net_cost, 
-  carbon.carbon_footprint_kgCO2e,
+  carbon.carbon_footprint_kgCO2e_scope1,
+  carbon.carbon_footprint_kgCO2e_scope2,
+  carbon.carbon_footprint_kgCO2e_scope3,
+  carbon.Total_carbon_footprint_kgCO2e,
   label_asset.labels,
   billing_usage.monthly_usage_volume
 FROM (
@@ -65,7 +68,10 @@ INNER JOIN (
     service.id AS service_id,
     project.number AS project_number,
     location.location AS location_location,
-    ROUND(carbon_footprint_kgCO2e, 3) AS carbon_footprint_kgCO2e,
+    ROUND(carbon_footprint_kgCO2e.scope1, 3) AS carbon_footprint_kgCO2e_scope1,
+    ROUND(carbon_footprint_kgCO2e.scope2.location_based, 3) AS carbon_footprint_kgCO2e_scope2,
+    ROUND(carbon_footprint_kgCO2e.scope3, 3) AS carbon_footprint_kgCO2e_scope3,
+    ROUND(carbon_footprint_total_kgCO2e.location_based, 3) AS Total_carbon_footprint_kgCO2e,
   FROM
     `$CARBON_PROJECT_ID.$CARBON_DATASET.$CARBON_TABLE` ) carbon
 ON

--- a/resources/view_template.sql
+++ b/resources/view_template.sql
@@ -17,7 +17,7 @@ SELECT
   carbon.carbon_footprint_kgCO2e_scope1,
   carbon.carbon_footprint_kgCO2e_scope2,
   carbon.carbon_footprint_kgCO2e_scope3,
-  carbon.Total_carbon_footprint_kgCO2e,
+  carbon.carbon_footprint_kgCO2e,
   label_asset.labels,
   billing_usage.monthly_usage_volume
 FROM (
@@ -71,7 +71,7 @@ INNER JOIN (
     ROUND(carbon_footprint_kgCO2e.scope1, 3) AS carbon_footprint_kgCO2e_scope1,
     ROUND(carbon_footprint_kgCO2e.scope2.location_based, 3) AS carbon_footprint_kgCO2e_scope2,
     ROUND(carbon_footprint_kgCO2e.scope3, 3) AS carbon_footprint_kgCO2e_scope3,
-    ROUND(carbon_footprint_total_kgCO2e.location_based, 3) AS Total_carbon_footprint_kgCO2e,
+    ROUND(carbon_footprint_total_kgCO2e.location_based, 3) AS carbon_footprint_kgCO2e,
   FROM
     `$CARBON_PROJECT_ID.$CARBON_DATASET.$CARBON_TABLE` ) carbon
 ON


### PR DESCRIPTION
PR updates the template_view.sql to be in line with new data model for carbon footprint exports to BigQuery. This includes, offsets, scope-wise breakup and location and market based footprint metrics.