### PR TITLE
Fix: Resolve Whitespace Issue in BigQuery View Creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ google-cloud-core==2.3.2 ; python_version >= '3.7'
 google-crc32c==1.5.0 ; python_version >= '3.7'
 google-resumable-media==2.5.0 ; python_version >= '3.7'
 googleapis-common-protos==1.59.0 ; python_version >= '3.7'
-grpcio==1.54.0 ; python_version >= '3.7'
-grpcio-status==1.54.0
+grpcio==1.60.1 ; python_version >= '3.7'
+grpcio-status==1.60.1
 idna==3.4 ; python_version >= '3.5'
 packaging==23.1 ; python_version >= '3.7'
 proto-plus==1.22.2 ; python_version >= '3.6'

--- a/resources/view_template.sql
+++ b/resources/view_template.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE VIEW
-  $VIEW_PROJECT_ID.$VIEW_DATASET.$VIEW_NAME AS
+  `$VIEW_PROJECT_ID.$VIEW_DATASET.$VIEW_NAME` AS
 SELECT
   billing.billing_account_id,
   STRUCT(billing.service_id AS id,


### PR DESCRIPTION
### Overview  
This pull request provides solutions for two critical issues in the project:  
1. Fixes [[Issue #7](https://github.com/bensadikgoogle/CarbonFootprintDashboardCreator/issues/7)](https://github.com/bensadikgoogle/CarbonFootprintDashboardCreator/issues/7), which reports a syntax error in BigQuery view creation caused by missing whitespace between literals and aliases.  
2. Addresses frequent timeout issues by upgrading the `grpcio` and `grpcio-status` packages to version 1.60.1.  

### Changes Made  
1. **BigQuery Syntax Fix**  
   - Escaped project, dataset, and table names with backticks (` `` `) to handle special characters (e.g., hyphens).  
   - Ensured that the SQL query generation now complies with BigQuery syntax requirements.  

2. **Package Upgrades**  
   - Upgraded `grpcio` and `grpcio-status` to version 1.60.1 to fix recurring timeout problems during pipeline execution.  
   - Updated `requirements.txt` to reflect the new versions.  

### Testing  
- Verified that the updated SQL query executes successfully in configurations containing special characters in project and dataset names.  
- Ran the pipeline multiple times with the upgraded `grpcio` version to confirm that timeout issues no longer occur.  

### Impact  
- Fixes the syntax error in view creation, allowing the pipeline to execute without interruptions.  
- Resolves timeout issues during BigQuery operations, significantly improving reliability and execution speed.  